### PR TITLE
fix avoid trigger change event when open

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -467,7 +467,10 @@
 					defaults[0] = defaults[0].replace(/(\d+)(th|nd|st)/,'$1');
 					defaults[1] = defaults[1].replace(/(\d+)(th|nd|st)/,'$1');
 				}
+        // set initiated  to avoid triggerring datepicker-change event 
+        initiated = false;
 				setDateRange(moment(defaults[0], ___format).toDate(),moment(defaults[1], ___format).toDate());
+        initiated = true;
 			}
 			box.slideDown(animationTime);
 		}


### PR DESCRIPTION
The datepicker-change event triggered when open, that's always not wanted.
