### PR TITLE
Added option to set the default time.

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -387,7 +387,7 @@
 				box.find('.apply-btn').hide();
 			}
 
-			var defaultTime = new Date();
+			var defaultTime = opt.defaultTime ? opt.defaultTime : new Date();
 			if (opt.startDate && compare_month(defaultTime,opt.startDate) < 0 ) defaultTime = moment(opt.startDate).toDate();
 			if (opt.endDate && compare_month(nextMonth(defaultTime),opt.endDate) > 0 ) defaultTime = prevMonth(moment(opt.endDate).toDate());
 


### PR DESCRIPTION
Sometimes you need control over the default time (not just date), especially if you have time enabled. Setting endDate isn't okay because that disables the selection of future dates.
