### PR TITLE
ability to get the date picker wrapper from input

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -368,6 +368,7 @@
 			clear: clearSelection,
 			close: closeDatePicker,
 			open: open,
+			getPicker: getPicker,
 			destroy: function()
 			{
 				$(self).unbind('.datepicker');
@@ -665,6 +666,12 @@
 		                    }
 		                }
 			}
+		}
+		
+		// Return the date picker wrapper element
+		function getPicker()
+		{
+			return box;
 		}
 
 		function open(animationTime)

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -368,7 +368,7 @@
 			clear: clearSelection,
 			close: closeDatePicker,
 			open: open,
-			getPicker: getPicker,
+			getDatePicker: getDatePicker,
 			destroy: function()
 			{
 				$(self).unbind('.datepicker');
@@ -669,7 +669,7 @@
 		}
 		
 		// Return the date picker wrapper element
-		function getPicker()
+		function getDatePicker()
 		{
 			return box;
 		}


### PR DESCRIPTION
If a user wants to make non-css changes to the date picker wrapper, there is no way to target it via the api. this adds a simple function returning 'box', a.k.a. the date-picker-wrapper.