### PR TITLE
close/reopen bug

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -341,9 +341,10 @@
 
 		$(this).unbind('.datepicker').bind('click.datepicker',function(evt)
 		{
+			var isOpen = box.is(':visible');
 			$(document).trigger('click.datepicker');
 			evt.stopPropagation();
-			open(opt.duration);
+			if(!isOpen) open(opt.duration);
 		});
 
 		init_datepicker.call(this);


### PR DESCRIPTION
if the date range picker is open and the user clicks the input again, the date picker closes and reopens. this will check its state and close the date picker.