### PR TITLE
Add custom value options for more flexible shortcuts

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -60,6 +60,23 @@ $(function()
 		language:'en'
 	});
 
+	$('#date-range105').dateRangePicker(
+	{
+		showCustomValues: true,
+		customValueLabel: 'Dynamic Ranges',
+		customValues:
+		[
+			{
+				name: 'MTD',
+				value: 'Month To Date'
+			},
+			{
+				name: 'YTD',
+				value: 'Year To Date'
+			}
+		]
+	})
+
 	$('#date-range100').dateRangePicker(
 	{
 		shortcuts : null,

--- a/index.html
+++ b/index.html
@@ -265,6 +265,30 @@
 			</div>
 
 			<div class="demo">
+				Use custom values: <input id="date-range105" size="60" value="">
+				<a href="#" class="show-option">Show Config</a>
+				<pre class="options">
+{
+	language:'en',
+	customValueLabel: 'Dynamic Ranges',
+	showCustomValues: true,
+	customValues:
+		//if return an array of two dates, it will select the date range between the two dates
+		[
+			{
+				name: 'MTD',
+				value: 'Month To Date'
+			},
+			{
+				name: 'YTD',
+				value: 'Year To Date'
+			}
+		]
+}				</pre>
+			</div>
+
+
+			<div class="demo">
 				Hide shortcuts: <input id="date-range104" size="60" value="">
 				<a href="#" class="show-option">Show Config</a>
 				<pre class="options">

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -124,6 +124,7 @@
 			'week-7' : 'SU',
 			'month-name': ['JANUARY','FEBRUARY','MARCH','APRIL','MAY','JUNE','JULY','AUGUST','SEPTEMBER','OCTOBER','NOVEMBER','DECEMBER'],
 			'shortcuts' : 'Shortcuts',
+			'custom-values': 'Custom Values',
 			'past': 'Past',
 			'following':'Following',
 			'previous' : 'Previous',
@@ -634,6 +635,19 @@
 					'date1' : new Date(opt.start),
 					'date2' : new Date(opt.end)
 				});
+			});
+
+			box.find('[custom]').click(function()
+			{
+				var valueName = $(this).attr('custom');
+				opt.start = false;
+				opt.end = false;
+				box.find('.day.checked').removeClass('checked');
+				opt.setValue.call(selfDom, valueName);
+				checkSelectionValid();
+				showSelectedInfo();
+				showSelectedDays();
+				closeDatePicker();
 			});
 
 			box.find('[shortcut]').click(function()
@@ -1395,6 +1409,21 @@
 					{
 						var sh = opt.customShortcuts[i];
 						html+= '&nbsp;<span class="custom-shortcut"><a href="javascript:;" shortcut="custom">'+sh.name+'</a></span>';
+					}
+				}
+
+				// Add Custom Values Dom
+				if (opt.showCustomValues)
+				{
+					html += '<div class="customValues"><b>'+(opt.customValueLabel || lang('custom-values'))+'</b>';
+
+					if (opt.customValues)
+					{
+						for(var i=0;i<opt.customValues.length;i++)
+						{
+							var val = opt.customValues[i];
+								html+= '&nbsp;<span class="custom-value"><a href="javascript:;" custom="'+ val.value+'">'+val.name+'</a></span>';
+						}
 					}
 				}
 


### PR DESCRIPTION
Useful for dynamic dates and non-date string shortcuts where the app has custom options for the date picker.
ie. "MTD", "QTD", "YTD"