### PR TITLE
Add config callbacks to modify td and div day tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The default configuration object is:
 	alwaysOpen:false,
 	singleDate:false,
 	batchMode:false,
-	beforeShowDay: [function]
+	beforeShowDay: [function],
+	dayDivAttrs: [],
+	dayTdAttrs: []
 }
 ```
 
@@ -144,6 +146,45 @@ if this is 0, means do not limit maximum days</i>
 [2]: an optional popup tooltip for this date
 The function is called for each day in the datepicker before it is displayed.</i>
 
+<b>dayDivAttrs (Array(Function))</b>
+<i>An array of functions that take the today as a parameter and must return an object, e.g. `{title: "unavailable", class: " red-unavailable "}`.
+The returned objects then merge, adding up existing keys (in order of callbacks in the array), so strings with same keys get concatenated and numbers result in the sum of them.
+The resulting object then turns into `div` tag of the day attributes.</i>
+
+```javascript
+{
+	dayDivAttrs: [
+		function(date){ // let's put bg colors and price per day attributes from php-prepared data array or put the default one
+			if(date == undefined) return {};
+			return ( rentdates(moment(date.time)) )?
+				{price: rentdates(moment(date.time)).price, title: '€' + rentdates(moment(date.time)).price}:
+				{price: rentprice, title: '€' + rentprice};
+		},                                        
+		function(date){ // let's underline saturdays and assign a title
+			if(date == undefined) return {};
+			return (moment(date.time).day()==6)?{'style': 'border-left: 2px lightgreen solid;border-right: 2px lightgreen solid;', 'title': '\nSaturday is the check-in day of week.'}:{};
+		},
+	]
+}
+```
+
+<b>dayTdAttrs (Array(Function))</b>
+<i>An array of functions that take the today as a parameter and must return an object, e.g. `{style: " background-color: red; "}`.
+The returned objects then merge, adding up existing keys (in order of callbacks in the array), so strings with same keys get concatenated and numbers result in the sum of them.
+The resulting object then turns into `td` tag of the day attributes.</i>
+
+```javascript
+{
+	dayTdAttrs: [
+		function(date){ // let's put bg colors from php-prepared data array
+			if(date == undefined) return {};
+			return ( rentdates(moment(date.time)) )?
+				{style: 'background-color: ' + rentdates(moment(date.time)).color + ';'}:
+				{};
+		},
+	]
+}
+```
 
 ##Events##
 

--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -93,7 +93,7 @@
 }
 .date-picker-wrapper .month-wrapper table .day.checked
 {
-	background-color: rgb(156, 219, 247);
+	background-color: rgba(156, 219, 247, 0.5);
 }
 .date-picker-wrapper .month-wrapper table .week-name
 {

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -392,7 +392,9 @@
 			lookBehind: false,
 			batchMode: false,
 			duration: 200,
-			stickyMonths: false
+			stickyMonths: false,
+			dayDivAttrs: [],
+			dayTdAttrs: []
 		},opt);
 
 		opt.start = false;
@@ -1466,6 +1468,32 @@
 			return html.join('');
 		}
 
+		function attributesCallbacks(initialObject,callbacksArray,today)
+		{
+			var resultObject = jQuery.extend(true, {}, initialObject);
+
+			callbacksArray.forEach(function(cbAttr,cbAttrIndex,cbAttrArray){
+				var addAttributes = cbAttr(this);
+				for(var attr in addAttributes){
+					if(resultObject.hasOwnProperty(attr)){
+						resultObject[attr] += addAttributes[attr];
+					}else{
+						resultObject[attr] = addAttributes[attr];
+					}
+				}
+			},today);
+
+			attrString = '';
+
+			for(var attr in resultObject){
+				if(resultObject.hasOwnProperty(attr)){
+					attrString += attr + '="' + resultObject[attr] + '" ';
+				}
+			}
+
+			return attrString;
+		}
+
 		function createMonthHTML(d)
 		{
 			var days = [];
@@ -1519,7 +1547,14 @@
 						today.tooltip = _r[2] || '';
 						if (today.tooltip != '') today.extraClass += ' has-tooltip ';
 					}
-					html.push('<td><div time="'+today.time+'" title="'+today.tooltip+'" class="day '+today.type+' '+today.extraClass+' '+(today.valid ? 'valid' : 'invalid')+' '+(highlightToday?'real-today':'')+'">'+today.day+'</div></td>');
+
+					todayDivAttr = {
+						time: today.time,
+						title: today.tooltip,
+						class: 'day '+today.type+' '+today.extraClass+' '+(today.valid ? 'valid' : 'invalid')+' '+(highlightToday?'real-today':'')
+					};
+
+					html.push('<td ' + attributesCallbacks({},opt.dayTdAttrs,today) + '><div ' + attributesCallbacks(todayDivAttr,opt.dayDivAttrs,today) + '>'+today.day+'</div></td>');
 				}
 				html.push('</tr>');
 			}


### PR DESCRIPTION
 * Checked days selector is made half-opaque, so td background could be visible
 * Arrays of callbacks allow to extend the td or div tags attributes: custom day colors, titles, other data