### PR TITLE
Fix module export and remove warning if moment is not in the global scope

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -7,13 +7,16 @@
 
 (function (factory) {
 		if (typeof define === 'function' && define.amd) {
-				// AMD. Register as an anonymous module.
-				define(['jquery'], factory);
+			// AMD. Register as an anonymous module.
+			define(['jquery', 'moment'], factory);
+		} else if (typeof exports === 'object' && typeof module !== 'undefined') {
+			// CommonJS. Register as a module
+			module.exports = factory(require('jquery'), require('moment')); 
 		} else {
-				// Browser globals
-				factory(jQuery);
+			// Browser globals
+			factory(jQuery, moment);
 		}
-}(function ($)
+}(function ($, moment)
 {
 
 	$.dateRangePickerLanguages =
@@ -350,13 +353,6 @@
 			'default-default': 'Válassz ki egy időszakot'
 		}
 	};
-
-
-	if (window['moment'] === undefined)
-	{
-		if (window['console'] && console['warn']) console.warn('Please import moment.js before daterangepicker.js');
-		return;
-	}
 
 	$.fn.dateRangePicker = function(opt)
 	{


### PR DESCRIPTION
First of all thanks for that plugin, really useful!

I started to use it yesterday and I couldn't make it work with moment 10.0.2, it turns out that momentJS has deprecated the access of its object through the global scope.

It turns out that moment 2.4.0+ wrote a warning in the console:

```
Deprecation warning: Accessing Moment through the global scope is deprecated, and will be removed in an upcoming release."
```

To fix that problem we just need to import the module the way you did with `jQuery`. 

I also noticed that you didn't write any `CommonJS` module export, so I added that.