### PR TITLE
added to new events, DTP opened and DTP closed-without-changes

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -819,6 +819,7 @@
         		initiated = true;
 			}
 			box.slideDown(animationTime);
+			$(self).trigger('datepicker-open');
 		}
 
 

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1259,6 +1259,15 @@
 			{
 				$(self).data('date-picker-opened',false);
 			});
+			if (opt.end && !(justClose === true)) {
+				$(self).trigger('drp-apply', {
+					'periodType': opt.periodType,
+					'date1' : new Date(opt.start),
+					'date2' : new Date(opt.end)
+				});
+			} else if (justClose === true) {
+				$(self).trigger('datepicker-close-without-changes');
+			}
 			//$(document).unbind('.datepicker');
 			$(self).trigger('datepicker-close');
 		}


### PR DESCRIPTION
im creating a SPA plattform and i need those events to store previous date if user doesnt click on the 'Update' button to return to the previous date.

DTP open -> to store currentDate
DTP close-without-changes -> to revert if user cancels the action.