### PR TITLE
Silent argument for setDateRange method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,12 @@ $('#dom-id')
 })
 .bind('datepicker-open',function()
 {
-  console.loge('open');
+  console.log('open');
 })
 .bind('datepicker-opened',function()
 {
   // fires event after animation finishes
-  console.loge('opened');
+  console.log('opened');
 })
 .bind('datepicker-close',function()
 {
@@ -229,7 +229,7 @@ $('#dom-id')
 .bind('datepicker-closed',function()
 {
   // fires event after animation finishes
-  console.loge('closed');
+  console.log('closed');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ $('#dom-id')
 after you called  $(dom).dateRangePicker();
 ```javascript
 $(dom).data('dateRangePicker')
-	.setDateRange('2013-11-20','2013-11-25');  //set date range, two date strings should follow the `format` in config object
+	.setDateRange('2013-11-20','2013-11-25');  //set date range, two date strings should follow the `format` in config object, set the third argument to be `true` if you don't want this method to trigger a `datepicker-change` event.
 	.clear(); 	// clear date range
 	.close(); 	// close date range picker overlay
 	.open();	// open date range picker overlay

--- a/demo.js
+++ b/demo.js
@@ -256,6 +256,8 @@ $(function()
 	{
 		showShortcuts: false,
 		format: 'YYYY-MM-DD'
+	}).bind('datepicker-change', function(evt, obj) {
+		alert('date1: ' + obj.date1 + ' / date2: ' + obj.date2);
 	});
 
 	$('#date-range16-open').click(function(evt)
@@ -274,6 +276,12 @@ $(function()
 	{
 		evt.stopPropagation();
 		$('#date-range16').data('dateRangePicker').setDateRange('2013-11-20','2014-08-25');
+	});
+
+	$('#date-range16-set-silent').click(function(evt)
+	{
+		evt.stopPropagation();
+		$('#date-range16').data('dateRangePicker').setDateRange('2014-11-03','2015-02-12', true);
 	});
 
 	$('#date-range16-clear').click(function(evt)

--- a/index.html
+++ b/index.html
@@ -380,6 +380,7 @@
 				<button id="date-range16-open">Open</button> 
 				<button id="date-range16-close">Close</button> 
 				<button id="date-range16-set">Set Date Range</button> 
+				<button id="date-range16-set-silent">Set Date Range (no event / silent: true)</button> 
 				<button id="date-range16-clear">Clear Selection</button> 
 				<button id="date-range16-destroy">Destroy</button> 
 				<br>
@@ -391,6 +392,8 @@ $('#date-range16').dateRangePicker(
 {
 	showShortcuts: false,
 	format: 'YYYY-MM-DD'
+}).bind('datepicker-change', function(evt, obj) {
+	alert('date1: ' + obj.date1 + ' / date2: ' + obj.date2);
 });
 
 $('#date-range16-open').click(function(evt)
@@ -409,6 +412,12 @@ $('#date-range16-set').click(function(evt)
 {
 	evt.stopPropagation();
 	$('#date-range16').data('dateRangePicker').setDateRange('2013-11-20','2014-08-25');
+});
+
+$('#date-range16-set-silent').click(function(evt)
+{
+	evt.stopPropagation();
+	$('#date-range16').data('dateRangePicker').setDateRange('2014-11-03','2015-02-12', true);
 });
 
 $('#date-range16-clear').click(function(evt)
@@ -593,7 +602,7 @@ $('#date-range16-destroy').click(function(evt)
 <pre>//after you called  $(dom).dateRangePicker();
 
 $(dom).data('dateRangePicker')
-	.setDateRange('2013-11-20','2013-11-25');  //set date range, two date strings should follow the `format` in config object
+	.setDateRange('2013-11-20','2013-11-25');  //set date range, two date strings should follow the `format` in config object, set the third argument to be `true` if you don't want this method to trigger a `datepicker-change` event.
 	.clear(); 	// clear date range
 	.close(); 	// close date range picker overlay
 	.open();	// open date range picker overlay

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -433,14 +433,15 @@
 		// expose some api
 		$(this).data('dateRangePicker',
 		{
-			setDateRange : function(d1,d2)
+			setDateRange : function(d1,d2,silent)
 			{
 				if (typeof d1 == 'string' && typeof d2 == 'string')
 				{
 					d1 = moment(d1,opt.format).toDate();
 					d2 = moment(d2,opt.format).toDate();
 				}
-				setDateRange(d1,d2);
+				silent === true ? true : false;
+				setDateRange(d1,d2,silent);
 			},
 			clear: clearSelection,
 			close: closeDatePicker,
@@ -1046,7 +1047,7 @@
 			}
 		}
 
-		function showSelectedInfo(forceValid)
+		function showSelectedInfo(forceValid, silent)
 		{
 			box.find('.start-day').html('...');
 			box.find('.end-day').html('...');
@@ -1081,7 +1082,7 @@
 				box.find('.apply-btn').removeClass('disabled');
 				var dateRange = getDateString(new Date(opt.start))+ opt.separator +getDateString(new Date(opt.end));
 				opt.setValue.call(selfDom,dateRange, getDateString(new Date(opt.start)), getDateString(new Date(opt.end)));
-				if (initiated)
+				if (initiated && !silent)
 				{
 					$(self).trigger('datepicker-change',
 					{
@@ -1101,7 +1102,7 @@
 			}
 		}
 
-		function setDateRange(date1,date2)
+		function setDateRange(date1,date2,silent)
 		{
 			if (date1.getTime() > date2.getTime())
 			{
@@ -1155,7 +1156,7 @@
 			showMonth(date1,'month1');
 			showMonth(date2,'month2');
 			showGap();
-			showSelectedInfo();
+			showSelectedInfo(false, silent);
 			autoclose();
 		}
 

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -440,7 +440,6 @@
 					d1 = moment(d1,opt.format).toDate();
 					d2 = moment(d2,opt.format).toDate();
 				}
-				silent === true ? true : false;
 				setDateRange(d1,d2,silent);
 			},
 			clear: clearSelection,
@@ -1050,7 +1049,7 @@
 			}
 		}
 
-		function showSelectedInfo(forceValid, silent)
+		function showSelectedInfo(forceValid,silent)
 		{
 			box.find('.start-day').html('...');
 			box.find('.end-day').html('...');
@@ -1159,7 +1158,7 @@
 			showMonth(date1,'month1');
 			showMonth(date2,'month2');
 			showGap();
-			showSelectedInfo(false, silent);
+			showSelectedInfo(false,silent);
 			autoclose();
 		}
 


### PR DESCRIPTION
I added on extra argument to the `setDateRange` method, when set to true this will avoid triggering the `datepicker-change` event.
I also updated the documentation and the demo page.