### PR TITLE
fix prevMonth and nextMonth calculation

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1285,18 +1285,12 @@
 
 		function nextMonth(month)
 		{
-			month = moment(month).toDate();
-			var toMonth = month.getMonth();
-			while(month.getMonth() == toMonth) month = new Date(month.getTime()+86400000);
-			return month;
+			return moment(month).startOf('month').add(1, 'month').toDate();
 		}
 
 		function prevMonth(month)
 		{
-			month = moment(month).toDate();
-			var toMonth = month.getMonth();
-			while(month.getMonth() == toMonth) month = new Date(month.getTime()-86400000);
-			return month;
+			return moment(month).startOf('month').subtract(1, 'month').toDate();
 		}
 
 		function getTimeHTML()


### PR DESCRIPTION
This pull request solves issue #79 and #81 .
The problem was that when you call `nextMonth` it returns a date element using your local time, and `prevMonth` returned one in GMT, all the time seems to use GMT therefore it couldn't work.

I re-wrote the `nextMonth` and `prevMonth` method so that it's easier to understand and it fixes the issue.