### PR TITLE
This fixes a bug where the time as set is overwritten

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1126,7 +1126,13 @@
 
 			opt.start = date1.getTime();
 			opt.end = date2.getTime();
-			if (opt.stickyMonths || (compare_day(date1,date2) > 0 && compare_month(date1,date2) == 0))
+
+      if (opt.time.enabled) {
+				renderTime("time1", date1);
+				renderTime("time2", date2);
+			}
+
+				if (opt.stickyMonths || (compare_day(date1,date2) > 0 && compare_month(date1,date2) == 0))
 			{
 				if (opt.lookBehind) {
 					date1 = prevMonth(date2);
@@ -1151,10 +1157,6 @@
 				}
 			}
 
-			if (opt.time.enabled) {
-				renderTime("time1", date1);
-				renderTime("time2", date2);
-			}
 			showMonth(date1,'month1');
 			showMonth(date2,'month2');
 			showGap();

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1127,12 +1127,12 @@
 			opt.start = date1.getTime();
 			opt.end = date2.getTime();
 
-      if (opt.time.enabled) {
+      			if (opt.time.enabled) {
 				renderTime("time1", date1);
 				renderTime("time2", date2);
 			}
 
-				if (opt.stickyMonths || (compare_day(date1,date2) > 0 && compare_month(date1,date2) == 0))
+			if (opt.stickyMonths || (compare_day(date1,date2) > 0 && compare_month(date1,date2) == 0))
 			{
 				if (opt.lookBehind) {
 					date1 = prevMonth(date2);


### PR DESCRIPTION
If you have a date range within the same month, the lines of code around 1130 do something akin to this:
               if (opt.lookBehind) {
                    date1 = prevMonth(date2);
                } else {
                    date2 = nextMonth(date1);

and THEN renders the time.

Date 2's time will be reset to have a time of whatever date1's time was set to.
So May 5 2015 07:30 - May 11 2015 11:30 becomes May 5 2015 07:30 - May 11 2015 07:30

this fixes the bug.
