### PR TITLE
Moves time rendering code to before the month change

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1126,6 +1126,12 @@
 
 			opt.start = date1.getTime();
 			opt.end = date2.getTime();
+
+			if (opt.time.enabled) {
+				renderTime("time1", date1);
+				renderTime("time2", date2);
+			}
+
 			if (opt.stickyMonths || (compare_day(date1,date2) > 0 && compare_month(date1,date2) == 0))
 			{
 				if (opt.lookBehind) {
@@ -1151,10 +1157,6 @@
 				}
 			}
 
-			if (opt.time.enabled) {
-				renderTime("time1", date1);
-				renderTime("time2", date2);
-			}
 			showMonth(date1,'month1');
 			showMonth(date2,'month2');
 			showGap();


### PR DESCRIPTION
This fixes a bug.
If you had date2 and date1 with different times, the code as of 1135 in this PR creates one of the dates based on the previous one, and that clobbers whatever time you may have set.

e.g.                 if (opt.lookBehind) {
                    date1 = prevMonth(date2);
                } else {
                    date2 = nextMonth(date1);
                }
            }

Putting the time render code ahead of this change preserves the UI functionality but also keeps the time information originally set in date2.