### PR TITLE
remove data `date-picker-opened` on destroy

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -450,6 +450,7 @@
 			{
 				$(self).unbind('.datepicker');
 				$(self).data('dateRangePicker','');
+				$(self).data('date-picker-opened',null);
 				box.remove();
 				$(window).unbind('resize.datepicker',calcPosition);
 				$(document).unbind('click.datepicker',closeDatePicker);


### PR DESCRIPTION
to fix issue: `dateRangePicker` cannot be initialized again on the same element after calling `destroy`.
reason: data `date-picker-opened` is checked in `init_datepicker`.