### PR TITLE
allow getDateString to be overridden

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -381,6 +381,10 @@
 					$(this).val(s);
 				}
 			},
+			getDateString: function(d)
+			{
+				return moment(d).format(opt.format);
+			},
 			startDate: false,
 			endDate: false,
 			time: {
@@ -674,7 +678,7 @@
 			box.find('.apply-btn').click(function()
 			{
 				closeDatePicker();
-				var dateRange = getDateString(new Date(opt.start))+ opt.separator +getDateString(new Date(opt.end));
+				var dateRange = opt.getDateString(new Date(opt.start))+ opt.separator +opt.getDateString(new Date(opt.end));
 				$(self).trigger('datepicker-apply',
 				{
 					'value': dateRange,
@@ -1265,18 +1269,18 @@
 			box.find('.selected-days').hide();
 			if (opt.start)
 			{
-				box.find('.start-day').html(getDateString(new Date(parseInt(opt.start))));
+				box.find('.start-day').html(opt.getDateString(new Date(parseInt(opt.start))));
 			}
 			if (opt.end)
 			{
-				box.find('.end-day').html(getDateString(new Date(parseInt(opt.end))));
+				box.find('.end-day').html(opt.getDateString(new Date(parseInt(opt.end))));
 			}
 
 			if (opt.start && opt.singleDate)
 			{
 				box.find('.apply-btn').removeClass('disabled');
-				var dateRange = getDateString(new Date(opt.start));
-				opt.setValue.call(selfDom, dateRange, getDateString(new Date(opt.start)), getDateString(new Date(opt.end)));
+				var dateRange = opt.getDateString(new Date(opt.start));
+				opt.setValue.call(selfDom, dateRange, opt.getDateString(new Date(opt.start)), opt.getDateString(new Date(opt.end)));
 
 				if (initiated)
 				{
@@ -1291,8 +1295,8 @@
 			{
 				box.find('.selected-days').show().find('.selected-days-num').html(countDays(opt.end, opt.start)+1);
 				box.find('.apply-btn').removeClass('disabled');
-				var dateRange = getDateString(new Date(opt.start))+ opt.separator +getDateString(new Date(opt.end));
-				opt.setValue.call(selfDom,dateRange, getDateString(new Date(opt.start)), getDateString(new Date(opt.end)));
+				var dateRange = opt.getDateString(new Date(opt.start))+ opt.separator +opt.getDateString(new Date(opt.end));
+				opt.setValue.call(selfDom,dateRange, opt.getDateString(new Date(opt.start)), opt.getDateString(new Date(opt.end)));
 				if (initiated && !silent)
 				{
 					$(self).trigger('datepicker-change',
@@ -1475,11 +1479,6 @@
 		function nameMonth(m)
 		{
 			return lang('month-name')[m];
-		}
-
-		function getDateString(d)
-		{
-			return moment(d).format(opt.format);
 		}
 
 		function showGap()


### PR DESCRIPTION
this allows custom date presentation, (e.g. if a user wants localized date range picker, but not localized output values)