### PR TITLE
Solution for issue 145

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The default configuration object is:
 	beforeShowDay: [function],
 	dayDivAttrs: [],
 	dayTdAttrs: [],
-	applyBtnClass: ''
+	applyBtnClass: '',
+    swapTime: true,
 }
 ```
 
@@ -223,6 +224,8 @@ be the timestamp of that day. Second parameter will be the date of that month.</
 <b>showTopbar (Boolean)</b>
 <i>If show the top bar.</i>
 
+<b>swapTime (Boolean)</b>
+<i>If true and if time is enabled, on choosing first enddate and than startdate, endtime and starttime will be swapped. If this configkey is false, only date will be swapped, time will stay constant. If time is disabled, this config key is not used.</i>
 
 ##Events##
 

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -453,7 +453,8 @@
 			{
 				return days > 1 ? days + ' ' + lang('days') : '';
 			},
-			showTopbar: true
+			showTopbar: true,
+            swapTime: true,
 		},opt);
 
 		opt.start = false;
@@ -1093,7 +1094,7 @@
 				var tmp = opt.end;
 				opt.end = handleEnd(opt.start);
 				opt.start = handleStart(tmp);
-				if (opt.time.enabled) {
+				if (opt.time.enabled && opt.swapTime) {
 					swapTime();
 				}
 			}


### PR DESCRIPTION
Add new configkey swapTime. If it is false and time is enabled: don't… call swapTime on choosing first endDate and than startDate

https://github.com/longbill/jquery-date-range-picker/issues/145