### PR TITLE
Fix silent mode for singleDate

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1520,7 +1520,7 @@
 				var dateRange = getDateString(new Date(opt.start));
 				opt.setValue.call(selfDom, dateRange, getDateString(new Date(opt.start)), getDateString(new Date(opt.end)));
 
-				if (initiated)
+				if (initiated && !silent)
 				{
 					$(self).trigger('datepicker-change',
 					{


### PR DESCRIPTION
This prevents datepicker-change being fired when setDateRange is used with singleDate option. I ran into infinite event loop without this fix.