### PR TITLE
add touchmove to time inputs for mobile devices

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -939,14 +939,14 @@
 				}
 			});
 
-			box.find(".time1 input[type=range]").bind("change mousemove", function (e) {
+			box.find(".time1 input[type=range]").bind("change touchmove mousemove", function (e) {
 				var target = e.target,
 					hour = target.name == "hour" ? $(target).val().replace(/^(\d{1})$/, "0$1") : undefined,
 					min = target.name == "minute" ? $(target).val().replace(/^(\d{1})$/, "0$1") : undefined;
 				setTime("time1", hour, min);
 			});
 
-			box.find(".time2 input[type=range]").bind("change mousemove", function (e) {
+			box.find(".time2 input[type=range]").bind("change touchmove mousemove", function (e) {
 				var target = e.target,
 					hour = target.name == "hour" ? $(target).val().replace(/^(\d{1})$/, "0$1") : undefined,
 					min = target.name == "minute" ? $(target).val().replace(/^(\d{1})$/, "0$1") : undefined;


### PR DESCRIPTION
I noticed that the time input sliders did not update the time on mobile devices.  Added touchmove listeners to those input sliders.