### PR TITLE
Prevent Loop

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1304,8 +1304,14 @@
 							valid = false;
 							break;
 						}
-						if (timeTmp > opt.start) timeTmp -= 86400000;
-						if (timeTmp < opt.start) timeTmp += 86400000;
+						if (timeTmp > opt.start) 
+						{
+							timeTmp -= 86400000;
+						}
+						else 
+						{
+							timeTmp += 86400000;
+						}
 					}
 					if (!valid) return false;
 				}


### PR DESCRIPTION
The existing check didn't account for timeTmp being the same as opt.start and could therefore get in a loop. The new check deals with that.