### PR TITLE
Prevent infinite loop

### DIFF
--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1304,6 +1304,7 @@
 							valid = false;
 							break;
 						}
+						if (Math.abs(timeTmp - opt.start) < 86400000) break;
 						if (timeTmp > opt.start) timeTmp -= 86400000;
 						if (timeTmp < opt.start) timeTmp += 86400000;
 					}


### PR DESCRIPTION
The different between timeTmp and opt.start may be less than a full day, in which case the loop will iterate forever. The cause for this is if there is a time zone change between timeTmp and opt.start (for example due to day lights saving time). This solution also makes sure that it doesn't get stuck if timeTmp and opt.start are the same value.