### PR TITLE
Option to set different default start and end times

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -102,7 +102,18 @@ $(function()
 			enabled: true
 		}
 	});
-	
+		$('#date-range1-1').dateRangePicker(
+	{
+		startOfWeek: 'monday',
+		separator : ' ~ ',
+		format: 'DD.MM.YYYY HH:mm',
+		autoClose: false,
+		time: {
+			enabled: true
+		},
+		defaultTime: moment().startOf('day').toDate(),
+		defaultEndTime: moment().endOf('day').toDate()
+	});
 	$('#date-range2').dateRangePicker();
 
 	$('#date-range3').dateRangePicker(

--- a/index.html
+++ b/index.html
@@ -88,6 +88,23 @@
 			</div>
 
 			<div class="demo">
+				Default settings with default start/end time value: <input id="date-range1-1" size="60" value="">
+				<a href="#" class="show-option">Show Config</a>
+				<pre class="options">
+{
+	startOfWeek: 'monday',
+	separator : ' ~ ',
+	format: 'DD.MM.YYYY HH:mm',
+	autoClose: false,
+	time: {
+		enabled: true
+	},
+	defaultTime: moment().startOf('day').toDate(),
+	defaultEndTime: moment().endOf('day').toDate()
+}</pre>
+			</div>
+
+			<div class="demo">
 				Default settings with default value: <input id="date-range2" size="40" value="2013-10-01 to 2013-11-04">
 				<a href="#" class="show-option">Show Config</a>
 				<pre class="options">

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -696,8 +696,9 @@
 					showTime(moment(opt.start || opt.startDate).toDate(),'time1');
 					showTime(moment(opt.end || opt.endDate).toDate(),'time2');
 				} else {
+					var defaultEndTime = opt.defaultEndTime ? opt.defaultEndTime : defaultTime;
 					showTime(defaultTime,'time1');
-					showTime(defaultTime,'time2');
+					showTime(defaultEndTime,'time2');
 				}
 			}
 


### PR DESCRIPTION
Added an option making it possible to set a default start and end time that are different. Many of the users of my application basically ignore the time slider and expect the start/end dates they select to be inclusive of those days. This allows the ability to set the start time to the beginning of a day and the end time to the end of a day by default.