### PR TITLE
Fix version badge not updating itself due to cache. Faster the builds Be reducing zip size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## jQuery Date Range Picker Plugin
 
-[![Bower Version](https://img.shields.io/bower/v/jquery-date-range-picker.svg?maxAge=2592000)]()
+[![Bower Version](https://img.shields.io/bower/v/jquery-date-range-picker.svg?maxAge=3600)]()
 [![License](https://img.shields.io/github/license/longbill/jquery-date-range-picker.svg?maxAge=2592000)]()
 
 jQuery Date Range Picker is a jQuery plugin that allows user to select a date range.
@@ -39,7 +39,7 @@ npm install
 ```
 gulp
 ```
-* Above command will generate new files by reading from ```src```
+* Above command will generate new files by reading from ```src``` folder
 
 ### Change log
 * See [changelog](CHANGELOG.md)

--- a/bower.json
+++ b/bower.json
@@ -21,13 +21,20 @@
     "picker",
     "range"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/longbill/jquery-date-range-picker.git"
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "preview.jpg",
+    "CHANGELOG.md",
+    "gulpfile.js"
   ],
   "dependencies": {
     "moment": ">=2.8.1",


### PR DESCRIPTION
* It seems that badge image is not updating the version number because of cache header. I reduced the cache time to 1 hour.
* When i try ```bower install jquery-date-range-picker```, it is also downloading ```preview.jpg``` and ```CHANGELOG.md```, Lets bower ignore them for faster downloads.

@holtkamp 
This time you no need to release a new version.
Thanks for your continuous encouragements. :smile: 