### PR TITLE
Changed compare_days to use english date format

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1900,7 +1900,7 @@
 
 		function compare_day(m1,m2)
 		{
-			var p = parseInt(moment(m1).format('YYYYMMDD')) - parseInt(moment(m2).format('YYYYMMDD'));
+			var p = parseInt(moment(m1).locale('en').format('YYYYMMDD')) - parseInt(moment(m2).locale('en').format('YYYYMMDD'));
 			if (p > 0 ) return 1;
 			if (p === 0) return 0;
 			return -1;


### PR DESCRIPTION
Currently, if using moment with locales and the lang set to "ar" (arabic), the compare_days function always returns -1.

moment(m1).format('YYYYMM') returns a date format in arabic and parseInt is unable to parse it into an integer, so it returns NaN. To resolve this, always get the date for comparison in an English based date format.

