### PR TITLE
momentjs complains about deprecated usage

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1892,6 +1892,10 @@
 
 		function compare_month(m1,m2)
 		{
+			if(!m2 || !m1) {
+				return -1;
+			}
+
 			var p = parseInt(moment(m1).format('YYYYMM')) - parseInt(moment(m2).format('YYYYMM'));
 			if (p > 0 ) return 1;
 			if (p === 0) return 0;
@@ -1900,6 +1904,11 @@
 
 		function compare_day(m1,m2)
 		{
+
+			if(!m2 || !m1) {
+				return -1;
+			}
+
 			var p = parseInt(moment(m1).format('YYYYMMDD')) - parseInt(moment(m2).format('YYYYMMDD'));
 			if (p > 0 ) return 1;
 			if (p === 0) return 0;

--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1892,27 +1892,28 @@
 
 		function compare_month(m1,m2)
 		{
-			if(!m2 || !m1) {
+
+			if( m1 && m2 )
+			{
+				return parseInt(moment(m1).format('YYYYMM')) - parseInt(moment(m2).format('YYYYMM'));
+			}
+			else
+			{
 				return -1;
 			}
-
-			var p = parseInt(moment(m1).format('YYYYMM')) - parseInt(moment(m2).format('YYYYMM'));
-			if (p > 0 ) return 1;
-			if (p === 0) return 0;
-			return -1;
 		}
 
 		function compare_day(m1,m2)
 		{
-
-			if(!m2 || !m1) {
+			
+			if( m1 && m2 )
+			{
+				return parseInt(moment(m1).format('YYYYMMDD')) - parseInt(moment(m2).format('YYYYMMDD'));
+			}
+			else
+			{
 				return -1;
 			}
-
-			var p = parseInt(moment(m1).format('YYYYMMDD')) - parseInt(moment(m2).format('YYYYMMDD'));
-			if (p > 0 ) return 1;
-			if (p === 0) return 0;
-			return -1;
 		}
 
 		function nextMonth(month)


### PR DESCRIPTION
A side effect of using momentjs in compare_month and compare_day with a value of false is causing moment to complain:

> Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.
Arguments: [object Object]

A solution is proposed herein.