### PR TITLE
Prevents a moment.js deprecated warning

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1711,7 +1711,7 @@
 				}
 			}
 
-			if(opt.stickyMonths && compare_month(date2,opt.endDate) > 0) {
+			if(opt.stickyMonths && opt.endDate === false || compare_month(date2,opt.endDate) > 0) {
 				date1 = prevMonth(date1);
 				date2 = prevMonth(date2);
 			}


### PR DESCRIPTION
If `false` is passed as a parameter to `compare_month()` we get the following warning message:

> Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.