### PR TITLE
Added methods to change dates and options on the fly

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -705,6 +705,28 @@
 		// expose some api
 		$(this).data('dateRangePicker',
 		{
+			setStart: function(d1)
+			{
+				var end = new Date()
+				end.setTime(opt.end);
+				if (typeof d1 == 'string')
+				{
+					d1 = moment(d1,opt.format).toDate();
+				}
+				setDateRange(d1, end);
+				return this;
+			},
+			setEnd: function(d2)
+			{
+				var start = new Date()
+				start.setTime(opt.start);
+				if (typeof d2 == 'string')
+				{
+					d2 = moment(d2,opt.format).toDate();
+				}
+				setDateRange(start, d2);
+				return this;
+			},
 			setDateRange : function(d1,d2,silent)
 			{
 				if (typeof d1 == 'string' && typeof d2 == 'string')
@@ -713,6 +735,13 @@
 					d2 = moment(d2,opt.format).toDate();
 				}
 				setDateRange(d1,d2,silent);
+				return this;
+			},
+			setOption: function (optionName, newValue)
+			{
+				opt[optionName] = newValue;
+				redrawDatePicker();
+				return this;
 			},
 			clear: clearSelection,
 			close: closeDatePicker,

--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -707,13 +707,11 @@
 		{
 			setStart: function(d1)
 			{
-				var end = new Date()
-				end.setTime(opt.end);
 				if (typeof d1 == 'string')
 				{
 					d1 = moment(d1,opt.format).toDate();
 				}
-				setDateRange(d1, end);
+				setSingleDate(d1);
 				return this;
 			},
 			setEnd: function(d2)


### PR DESCRIPTION
This should solve issue #208. I've also added `return this` to these methods as well as `setDateRange` to allow chaining. This allows you to do the following:

```
$("#elem")
    .data('dateRangePicker')
    .setOption("selectForward", false)
    .setStart('2016-07-01')
    .setEnd('2016-07-02');
```