### PR TITLE
autoclose() should trigger datepicker-apply

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1357,6 +1357,7 @@
 			showSelectedInfo();
 			showSelectedDays();
 			autoclose();
+			if (opt.start && opt.end) triggerApply();
 		}
 
 
@@ -1386,6 +1387,7 @@
 			showSelectedInfo();
 			showSelectedDays();
 			autoclose();
+			triggerApply();
 		}
 
 		function isValidTime(time)
@@ -1557,6 +1559,26 @@
 				{
 					if (opt.autoClose) closeDatePicker();
 				}
+			}
+		}
+		
+		function triggerApply()
+		{
+			if (opt.singleDate === true) {
+				var dateRange = getDateString(new Date(opt.start));
+				$(self).trigger('datepicker-apply',
+				{
+					'value': dateRange,
+					'date1' : new Date(opt.start)
+				});
+			} else {
+				var dateRange = getDateString(new Date(opt.start))+ opt.separator +getDateString(new Date(opt.end));
+				$(self).trigger('datepicker-apply',
+				{
+					'value': dateRange,
+					'date1' : new Date(opt.start),
+					'date2' : new Date(opt.end)
+				});
 			}
 		}
 


### PR DESCRIPTION
When `autoclose` is set to `true`, there is no way to listen to an event where the second date is chosen specifically by the user. If you bind to `datepicker-change` this is also triggered when changing the date programatically using `setDateRange()`, so you can't differentiate between this and being changed by the user. It makes sense to me that `autoclose` should also auto-apply.