### PR TITLE
Fixed Swap Time function

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1366,8 +1366,10 @@
         }
 
         function swapTime() {
-            renderTime('time1', opt.start);
-            renderTime('time2', opt.end);
+            const temp_start = opt.end;
+            const temp_end = opt.start;
+            renderTime('time1', temp_start);
+            renderTime('time2', temp_end);
         }
 
         function setTime(name, hour, minute) {


### PR DESCRIPTION
Swap time currently serves no purpose - fixed to correctly swap start and end times when end date is selected first.