### PR TITLE
Fix changes to month dropdown

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -1675,7 +1675,7 @@
         }
 
         function dateChanged(date) {
-            var value = date.val();
+            var value = parseInt(date.val(), 10);
             var name = date.attr('name');
             var type = date.parents('table').hasClass('month1') ? 'month1' : 'month2';
             var oppositeType = type === 'month1' ? 'month2' : 'month1';


### PR DESCRIPTION
When using the month dropdown option changes don’t take effect because
moment(opt[type])[name](value) is passed a string. The momentJS docs
state that this works when name===‘month’ but testing reveals that this
isn’t the case. Always passing a Number instead of a String always
works.