### PR TITLE
Add a `main` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "jQuery Date Range Picker is a jQuery plugin that allows user to select a date range.",
   "version": "0.18.0",
   "license": "MIT",
+  "main": "src/jquery.daterangepicker.js",
   "keywords": [
     "jquery",
     "date",


### PR DESCRIPTION
We have this package as a NPM dependency, but directly to the repository, because the NPM-published version seems to be outdated.

We're using this package in an application where the build tools use https://github.com/webpack/enhanced-resolve. At some point the tools try to resolve `jquery-date-range-picker`, but fails because there's no `main`, `browser` or `module` field in the `package.json` file (see #438).

This PR adds a `main` field that points to the main entry point of the package, so that it may be properly resolved when necessary.